### PR TITLE
smooth scrolling and id anchor navigation

### DIFF
--- a/src/components/AnimatedSection.jsx
+++ b/src/components/AnimatedSection.jsx
@@ -4,15 +4,19 @@ const AnimatedSection = ({
   children, 
   className = '', 
   animationType = 'reveal-up',
-  delay = 0 
+  delay = 0,
+  id,
+  ...restProps
 }) => {
   const ref = useScrollAnimation();
 
   return (
     <div 
       ref={ref}
+      id={id}
       className={`${animationType} ${className}`}
       style={{ transitionDelay: `${delay}s` }}
+      {...restProps}
     >
       {children}
     </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,11 +3,13 @@ import { Link, useLocation } from 'react-router-dom';
 import { Menu, X } from 'lucide-react';
 import MobileNav from './MobileNav';
 import navigationData from '../data/navigation.json';
+import useScrollNavigation from '../hooks/useScrollNavigation';
 
 const Header = () => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
   const location = useLocation();
+  const handleNavigation = useScrollNavigation();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -36,9 +38,14 @@ const Header = () => {
           </Link>
           <nav className="main-nav-desktop">
             {navigationData.mainNavigation.map((item) => (
-              <Link key={item.id} to={item.href} className="nav-link">
+              <button 
+                key={item.id} 
+                onClick={() => handleNavigation(item.href)}
+                className="nav-link"
+                style={{ background: 'none', border: 'none', cursor: 'pointer' }}
+              >
                 {item.label}
-              </Link>
+              </button>
             ))}
           </nav>
           <button 
@@ -52,7 +59,8 @@ const Header = () => {
       </header>
       <MobileNav 
         isOpen={isMobileNavOpen} 
-        onClose={() => setIsMobileNavOpen(false)} 
+        onClose={() => setIsMobileNavOpen(false)}
+        handleNavigation={handleNavigation}
       />
     </>
   );

--- a/src/components/MobileNav.jsx
+++ b/src/components/MobileNav.jsx
@@ -1,18 +1,17 @@
-import { Link } from 'react-router-dom';
 import navigationData from '../data/navigation.json';
 
-const MobileNav = ({ isOpen, onClose }) => {
+const MobileNav = ({ isOpen, onClose, handleNavigation }) => {
   return (
     <nav className={`mobile-nav ${isOpen ? 'is-active' : ''}`}>
       {navigationData.mainNavigation.map((item) => (
-        <Link 
+        <button 
           key={item.id} 
-          to={item.href} 
+          onClick={() => handleNavigation(item.href, onClose)}
           className="nav-link"
-          onClick={onClose}
+          style={{ background: 'none', border: 'none', cursor: 'pointer' }}
         >
           {item.label}
-        </Link>
+        </button>
       ))}
     </nav>
   );

--- a/src/hooks/useScrollNavigation.js
+++ b/src/hooks/useScrollNavigation.js
@@ -1,0 +1,62 @@
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useCallback } from 'react';
+
+const useScrollNavigation = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const scrollToElement = useCallback((targetId) => {
+    const element = document.getElementById(targetId);
+    if (element) {
+      // Calculate header height offset
+      const header = document.querySelector('.main-header');
+      const headerHeight = header ? header.offsetHeight : 100; // fallback to 100px
+      const additionalOffset = 20; // Extra space for better visual separation
+      
+      // Get element position
+      const elementPosition = element.getBoundingClientRect().top + window.pageYOffset;
+      const offsetPosition = elementPosition - headerHeight - additionalOffset;
+
+      // Smooth scroll to calculated position
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: 'smooth'
+      });
+    }
+  }, []);
+
+  const handleNavigation = useCallback((href, onClose) => {
+    // Close mobile menu if provided
+    if (onClose) {
+      onClose();
+    }
+
+    // Check if it's a hash link (starts with /#)
+    if (href.startsWith('/#')) {
+      const targetId = href.substring(2); // Remove '/#' to get the id
+      
+      // If we're already on the home page, just scroll to the element
+      if (location.pathname === '/') {
+        scrollToElement(targetId);
+      } else {
+        // Navigate to home page first, then scroll after navigation
+        navigate('/');
+        // Use setTimeout to ensure the page has loaded before scrolling
+        setTimeout(() => {
+          scrollToElement(targetId);
+        }, 100);
+      }
+    } else {
+      // Regular navigation for non-hash links
+      navigate(href);
+      // Scroll to top for regular page navigation
+      setTimeout(() => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }, 50);
+    }
+  }, [navigate, location, scrollToElement]);
+
+  return handleNavigation;
+};
+
+export default useScrollNavigation;

--- a/src/index.css
+++ b/src/index.css
@@ -403,7 +403,7 @@ a { color: inherit; text-decoration: none; transition: background-color 0.2s eas
 }
 .mobile-nav { display: flex; flex-direction: column; justify-content: center; align-items: center; gap: 2rem; position: fixed; top: 0; left: 0; width: 100%; height: 100vh; height: 100svh; background: var(--main-bg); opacity: 0; visibility: hidden; transform: scale(0.95); transition: opacity 0.4s ease, visibility 0s 0.4s, transform 0.4s ease; z-index: 999; }
 .mobile-nav.is-active { opacity: 1; visibility: visible; transform: scale(1); }
-.mobile-nav .nav-link { font-size: 2rem; }
+.mobile-nav .nav-link { font-size: 2rem; color: inherit; font-family: inherit; }
 
 /* Masaüstü Stilleri (993px ve üstü) */
 @media (min-width: 993px) {
@@ -419,7 +419,7 @@ a { color: inherit; text-decoration: none; transition: background-color 0.2s eas
     .hamburger { display: none; }
     .mobile-nav { display: none; }
     .main-nav-desktop { display: flex; align-items: center; gap: 1rem; }
-    .main-nav-desktop .nav-link { font-size: var(--font-size-small); padding: 8px 12px; border-radius: 10px; transition: background-color 0.2s; }
+    .main-nav-desktop .nav-link { font-size: var(--font-size-small); padding: 8px 12px; border-radius: 10px; transition: background-color 0.2s; color: inherit; font-family: inherit; }
     .main-nav-desktop .nav-link:hover { background-color: var(--dark-gray); }
 }
 


### PR DESCRIPTION
This pull request refactors the navigation system to provide smooth scrolling to page sections when using navigation links, both on desktop and mobile. It introduces a new `useScrollNavigation` hook to handle navigation and scrolling logic, and updates navigation components to use buttons instead of links for section navigation. It also ensures consistent styling between navigation elements.

Navigation logic improvements:

* Added a new `useScrollNavigation` hook (`src/hooks/useScrollNavigation.js`) that manages smooth scrolling to sections, handles navigation between routes, and accounts for header offset.
* Updated the `Header` and `MobileNav` components to use the `handleNavigation` function from the new hook, replacing `<Link>` elements with `<button>` elements for section navigation. This enables smooth scrolling and closes the mobile menu when navigating. (`src/components/Header.jsx` [[1]](diffhunk://#diff-8c468c347b974539dbc7411567675397475e1aeac509adf899831746084c1179R6-R12) [[2]](diffhunk://#diff-8c468c347b974539dbc7411567675397475e1aeac509adf899831746084c1179L39-R48) [[3]](diffhunk://#diff-8c468c347b974539dbc7411567675397475e1aeac509adf899831746084c1179R63); `src/components/MobileNav.jsx` [[4]](diffhunk://#diff-b414231d3b77a41333b86cc8bf8c59df886bf3a54f845c18d9b678fd6a773173L1-R14)

Component and prop enhancements:

* Updated `AnimatedSection` to accept an `id` prop and spread additional props, allowing it to be targeted by the smooth scroll navigation. (`src/components/AnimatedSection.jsx` [src/components/AnimatedSection.jsxL7-R19](diffhunk://#diff-7522487fe356fae4494597da542d996b5cf4fb7fbbbdf7c65d521d798b659816L7-R19))

Styling consistency:

* Ensured that navigation buttons in both mobile and desktop views have consistent font and color styles, matching the appearance of links. (`src/index.css` [[1]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL406-R406) [[2]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL422-R422)