### PR TITLE
google sitemap

### DIFF
--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -1,0 +1,41 @@
+name: Update Sitemap
+
+on:
+  schedule:
+    # Her gün saat 02:00'da çalış
+    - cron: '0 2 * * *'
+  workflow_dispatch: # Manuel tetikleme
+
+jobs:
+  update-sitemap:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Generate sitemap
+      run: npm run sitemap
+      env:
+        VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+        VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+        VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+        VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+        VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+        VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+    
+    - name: Commit and push if changed
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add public/sitemap.xml
+        git diff --staged --quiet || git commit -m "Update sitemap.xml"
+        git push

--- a/api/update-sitemap.js
+++ b/api/update-sitemap.js
@@ -1,0 +1,24 @@
+// Vercel serverless function örneği
+// api/update-sitemap.js
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  try {
+    // Firebase webhook'tan gelen veriyi işle
+    const { articleSlug, action } = req.body;
+    
+    // Sitemap'i yeniden oluştur
+    // (generate-sitemap.js kodunu buraya adapte edin)
+    
+    res.status(200).json({ 
+      message: 'Sitemap updated successfully',
+      timestamp: new Date().toISOString()
+    });
+  } catch (error) {
+    console.error('Sitemap update error:', error);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,13 @@
 <!doctype html>
 <html lang="tr">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-MQG924RK');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -11,6 +18,10 @@
     <link href="/src/index.css" rel="stylesheet">
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MQG924RK"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && npm run sitemap",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "sitemap": "node scripts/generate-sitemap.js",
+    "sitemap:manual": "node scripts/generate-sitemap.js"
   },
   "dependencies": {
     "@lexical/html": "^0.34.0",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+        http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+
+  <!-- Ana Sayfa -->
+  <url>
+    <loc>https://ogwyn.com/</loc>
+    <lastmod>2024-09-14</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+  <!-- Bülten Sayfası -->
+  <url>
+    <loc>https://ogwyn.com/bulten</loc>
+    <lastmod>2024-09-14</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- Broadcast Sayfası -->
+  <url>
+    <loc>https://ogwyn.com/broadcast</loc>
+    <lastmod>2024-09-14</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- Hub Sayfası -->
+  <url>
+    <loc>https://ogwyn.com/hub</loc>
+    <lastmod>2024-09-14</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- Mağaza Sayfası -->
+  <url>
+    <loc>https://ogwyn.com/magaza</loc>
+    <lastmod>2024-09-14</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- Ogwyn AI Sayfası -->
+  <url>
+    <loc>https://ogwyn.com/ogwyn-ai</loc>
+    <lastmod>2024-09-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- İletişim Sayfası -->
+  <url>
+    <loc>https://ogwyn.com/iletisim</loc>
+    <lastmod>2024-09-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- Gizlilik Politikası -->
+  <url>
+    <loc>https://ogwyn.com/gizlilik-politikasi</loc>
+    <lastmod>2024-09-14</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <!-- 
+  Makale URL'leri dinamik olarak Firebase'den geldiği için,
+  yeni makaleler eklendiğinde bu sitemap güncellenmeli veya
+  dinamik sitemap oluşturma sistemi kurulmalıdır.
+  
+  Örnek makale URL formatı:
+  <url>
+    <loc>https://ogwyn.com/article/makale-slug-ornegi</loc>
+    <lastmod>2024-09-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  -->
+
+</urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -4,82 +4,60 @@
         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
         http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
-  <!-- Ana Sayfa -->
   <url>
     <loc>https://ogwyn.com/</loc>
-    <lastmod>2024-09-14</lastmod>
+    <lastmod>2025-09-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
-  <!-- Bülten Sayfası -->
   <url>
     <loc>https://ogwyn.com/bulten</loc>
-    <lastmod>2024-09-14</lastmod>
+    <lastmod>2025-09-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
-  <!-- Broadcast Sayfası -->
   <url>
     <loc>https://ogwyn.com/broadcast</loc>
-    <lastmod>2024-09-14</lastmod>
+    <lastmod>2025-09-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
-  <!-- Hub Sayfası -->
   <url>
     <loc>https://ogwyn.com/hub</loc>
-    <lastmod>2024-09-14</lastmod>
+    <lastmod>2025-09-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
-  <!-- Mağaza Sayfası -->
   <url>
     <loc>https://ogwyn.com/magaza</loc>
-    <lastmod>2024-09-14</lastmod>
+    <lastmod>2025-09-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
-  <!-- Ogwyn AI Sayfası -->
   <url>
     <loc>https://ogwyn.com/ogwyn-ai</loc>
-    <lastmod>2024-09-14</lastmod>
+    <lastmod>2025-09-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
-  <!-- İletişim Sayfası -->
   <url>
     <loc>https://ogwyn.com/iletisim</loc>
-    <lastmod>2024-09-14</lastmod>
+    <lastmod>2025-09-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
-  <!-- Gizlilik Politikası -->
   <url>
     <loc>https://ogwyn.com/gizlilik-politikasi</loc>
-    <lastmod>2024-09-14</lastmod>
+    <lastmod>2025-09-15</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
-
-  <!-- 
-  Makale URL'leri dinamik olarak Firebase'den geldiği için,
-  yeni makaleler eklendiğinde bu sitemap güncellenmeli veya
-  dinamik sitemap oluşturma sistemi kurulmalıdır.
-  
-  Örnek makale URL formatı:
-  <url>
-    <loc>https://ogwyn.com/article/makale-slug-ornegi</loc>
-    <lastmod>2024-09-14</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  -->
 
 </urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,56 +6,56 @@
 
   <url>
     <loc>https://ogwyn.com/</loc>
-    <lastmod>2025-09-16</lastmod>
+    <lastmod>2025-09-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/bulten</loc>
-    <lastmod>2025-09-16</lastmod>
+    <lastmod>2025-09-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/broadcast</loc>
-    <lastmod>2025-09-16</lastmod>
+    <lastmod>2025-09-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/hub</loc>
-    <lastmod>2025-09-16</lastmod>
+    <lastmod>2025-09-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/magaza</loc>
-    <lastmod>2025-09-16</lastmod>
+    <lastmod>2025-09-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/ogwyn-ai</loc>
-    <lastmod>2025-09-16</lastmod>
+    <lastmod>2025-09-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/iletisim</loc>
-    <lastmod>2025-09-16</lastmod>
+    <lastmod>2025-09-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/gizlilik-politikasi</loc>
-    <lastmod>2025-09-16</lastmod>
+    <lastmod>2025-09-17</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,56 +6,56 @@
 
   <url>
     <loc>https://ogwyn.com/</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2025-09-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/bulten</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2025-09-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/broadcast</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2025-09-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/hub</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2025-09-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/magaza</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2025-09-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/ogwyn-ai</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2025-09-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/iletisim</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2025-09-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/gizlilik-politikasi</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2025-09-16</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,109 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore, collection, getDocs } from 'firebase/firestore';
+import fs from 'fs';
+import path from 'path';
+
+// Firebase config - .env dosyanızdan alınacak
+const firebaseConfig = {
+  apiKey: process.env.VITE_FIREBASE_API_KEY,
+  authDomain: process.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.VITE_FIREBASE_APP_ID
+};
+
+// Firebase'i başlat
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+
+// Site base URL'i - kendi domain'inizle değiştirin
+const BASE_URL = 'https://ogwyn.com';
+
+// Statik sayfalar
+const staticPages = [
+  { url: '/', priority: '1.0', changefreq: 'weekly' },
+  { url: '/bulten', priority: '0.8', changefreq: 'weekly' },
+  { url: '/broadcast', priority: '0.8', changefreq: 'weekly' },
+  { url: '/hub', priority: '0.8', changefreq: 'weekly' },
+  { url: '/magaza', priority: '0.8', changefreq: 'weekly' },
+  { url: '/ogwyn-ai', priority: '0.8', changefreq: 'monthly' },
+  { url: '/iletisim', priority: '0.7', changefreq: 'monthly' },
+  { url: '/gizlilik-politikasi', priority: '0.3', changefreq: 'yearly' }
+];
+
+async function generateSitemap() {
+  try {
+    console.log('🚀 Sitemap oluşturuluyor...');
+    
+    // Firebase'den makaleleri çek
+    const articlesRef = collection(db, 'articles');
+    const articlesSnapshot = await getDocs(articlesRef);
+    
+    const articles = [];
+    articlesSnapshot.forEach((doc) => {
+      const data = doc.data();
+      if (data.slug && data.published) { // Sadece yayınlanmış makaleler
+        articles.push({
+          slug: data.slug,
+          lastmod: data.updatedAt || data.createdAt || new Date().toISOString(),
+          title: data.title
+        });
+      }
+    });
+
+    console.log(`📰 ${articles.length} makale bulundu`);
+
+    // XML sitemap oluştur
+    let sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+        http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+
+`;
+
+    // Statik sayfaları ekle
+    staticPages.forEach(page => {
+      const lastmod = new Date().toISOString().split('T')[0];
+      sitemap += `  <url>
+    <loc>${BASE_URL}${page.url}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>${page.changefreq}</changefreq>
+    <priority>${page.priority}</priority>
+  </url>
+
+`;
+    });
+
+    // Makale sayfalarını ekle
+    articles.forEach(article => {
+      const lastmod = new Date(article.lastmod).toISOString().split('T')[0];
+      sitemap += `  <url>
+    <loc>${BASE_URL}/article/${article.slug}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+`;
+    });
+
+    sitemap += `</urlset>`;
+
+    // Sitemap dosyasını kaydet
+    const sitemapPath = path.join(process.cwd(), 'public', 'sitemap.xml');
+    fs.writeFileSync(sitemapPath, sitemap, 'utf8');
+
+    console.log('✅ Sitemap başarıyla oluşturuldu!');
+    console.log(`📍 Konum: ${sitemapPath}`);
+    console.log(`📊 Toplam URL: ${staticPages.length + articles.length}`);
+    
+  } catch (error) {
+    console.error('❌ Sitemap oluşturulurken hata:', error);
+    process.exit(1);
+  }
+}
+
+// Script'i çalıştır
+generateSitemap();


### PR DESCRIPTION
This pull request introduces automated and manual sitemap generation and updating for the project, integrates Google Tag Manager, and adds a serverless API endpoint for triggering sitemap updates. The changes improve SEO, analytics, and content freshness by ensuring the sitemap reflects published articles and static pages.

**Sitemap Automation & Generation**

* Added a GitHub Actions workflow (`.github/workflows/update-sitemap.yml`) to automatically generate and update the sitemap daily at 2:00 AM and on manual trigger, including committing and pushing changes to `public/sitemap.xml`.
* Introduced a script (`scripts/generate-sitemap.js`) that builds a dynamic sitemap by fetching published articles from Firebase and combining them with static pages, then writes the result to `public/sitemap.xml`.
* Updated `package.json` scripts to run sitemap generation after builds and provide manual commands for generating the sitemap.
* Added a sample sitemap file (`public/sitemap.xml`) as a template for the generated output.

**API & Integration**

* Added a Vercel serverless function (`api/update-sitemap.js`) to allow external systems (e.g., Firebase webhooks) to trigger sitemap regeneration via a POST request, improving real-time SEO updates for new or changed articles.

**Analytics**

* Integrated Google Tag Manager into `index.html` for improved site analytics and tracking, including both script and noscript tags for full coverage. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R4-R10) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R21-R24)