### PR TITLE
fix: fixed sitemap generation bug

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,58 +6,65 @@
 
   <url>
     <loc>https://ogwyn.com/</loc>
-    <lastmod>2025-09-17</lastmod>
+    <lastmod>2025-09-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/bulten</loc>
-    <lastmod>2025-09-17</lastmod>
+    <lastmod>2025-09-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/broadcast</loc>
-    <lastmod>2025-09-17</lastmod>
+    <lastmod>2025-09-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/hub</loc>
-    <lastmod>2025-09-17</lastmod>
+    <lastmod>2025-09-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/magaza</loc>
-    <lastmod>2025-09-17</lastmod>
+    <lastmod>2025-09-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/ogwyn-ai</loc>
-    <lastmod>2025-09-17</lastmod>
+    <lastmod>2025-09-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/iletisim</loc>
-    <lastmod>2025-09-17</lastmod>
+    <lastmod>2025-09-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ogwyn.com/gizlilik-politikasi</loc>
-    <lastmod>2025-09-17</lastmod>
+    <lastmod>2025-09-26</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://ogwyn.com/article/yapay-zeka-devrimi-ve-dijital-trendler</loc>
+    <lastmod>2025-09-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
   </url>
 
 </urlset>


### PR DESCRIPTION
This pull request updates the sitemap generation process and the static `sitemap.xml` file to improve reliability and coverage. The main changes include better environment variable validation for Firebase configuration, more robust handling of article data from Firestore, and the addition of a new article to the static sitemap.

**Sitemap improvements:**

* Added a new article entry for `yapay-zeka-devrimi-ve-dijital-trendler` to `public/sitemap.xml`, including its metadata.
* Updated all `<lastmod>` dates in `public/sitemap.xml` to `2025-09-26` for consistency.

**Sitemap generation script enhancements:**

* Added dotenv support to `scripts/generate-sitemap.js` to load environment variables from a `.env` file, improving local development and deployment reliability.
* Implemented validation for required Firebase environment variables before initializing the Firestore client, with clear warnings if any are missing or if initialization fails.
* Improved Firestore article fetching logic to:
  - Support multiple ways of marking an article as published (`published`, `status` field).
  - Robustly handle Firestore timestamps for the `lastmod` field, including error handling for date conversion issues.